### PR TITLE
Fix FastMCP import and dependencies to resolve server startup issues

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ import logging
 import sys
 from typing import Dict, Any, List, Optional, Union
 
-from fastmcp import FastMCP
+from mcp.server.fastmcp import FastMCP
 from pydantic import BaseModel, Field
 
 from config import Config

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,19 @@
 # Qlik-MCP-server Dependencies
 
-# FastMCP framework for MCP server implementation
-fastmcp>=0.1.0
+# Core MCP dependencies (official MCP library)
+mcp>=1.6.0
 
 # Standard library extensions
 pydantic>=2.0.0
 typing-extensions>=4.0.0
 
-# For subprocess management and CLI integration
-subprocess32>=3.5.4; python_version < '3.0'
-
 # For configuration and data handling
 pyyaml>=6.0
 python-dotenv>=1.0.0
 
-# For logging and debugging
-structlog>=23.0.0
+# HTTP and networking (required by MCP)
+httpx>=0.28.0
+anyio>=4.0.0
 
-# For async operations
-asyncio-mqtt>=0.11.0
+# Additional dependencies that may be needed
+requests>=2.32.0


### PR DESCRIPTION
Fixes #7 

## Problem
The Qlik-MCP-server was not starting properly due to incorrect FastMCP import and incompatible dependencies, while the Github-MCP-server works correctly.

## Root Cause Analysis
After comparing both repositories, I identified the main issues:

1. **Incorrect FastMCP import**: Qlik-server used `from fastmcp import FastMCP` while the working Github-server uses `from mcp.server.fastmcp import FastMCP`
2. **Wrong dependencies**: Qlik-server used `fastmcp>=0.1.0` (possibly outdated/incompatible) instead of the official `mcp>=1.6.0` library
3. **Unnecessary dependencies**: Several unused dependencies that could cause conflicts

## Changes Made

### 1. Fixed FastMCP Import (app.py)
- Changed from `from fastmcp import FastMCP` to `from mcp.server.fastmcp import FastMCP`
- This aligns with the working Github-MCP-server implementation

### 2. Updated Dependencies (requirements.txt)
- **Replaced**: `fastmcp>=0.1.0` → `mcp>=1.6.0` (official MCP library)
- **Removed unnecessary dependencies**:
  - `subprocess32>=3.5.4` (outdated, Python 2 compatibility)
  - `asyncio-mqtt>=0.11.0` (not used in code)
  - `structlog>=23.0.0` (not used in code)
- **Added essential MCP dependencies**:
  - `httpx>=0.28.0` (required by MCP)
  - `anyio>=4.0.0` (required by MCP)
  - `requests>=2.32.0` (commonly needed)
- **Kept Qlik-specific dependencies**:
  - `pyyaml>=6.0`
  - `python-dotenv>=1.0.0`

## Expected Result
- Server should now start properly without import errors
- Dependencies are aligned with the working Github-MCP-server
- Reduced potential for dependency conflicts
- Maintained all Qlik-specific functionality

## Testing Recommendations
1. Install updated dependencies: `pip install -r requirements.txt`
2. Test server startup: `python app.py`
3. Verify MCP tools are available and functional
4. Test connection to Qlik Cloud

This fix addresses the core issues identified in the bug report and aligns the Qlik-MCP-server with the proven working implementation of the Github-MCP-server.