### PR TITLE
Fix QLIK_DEFAULT_UNBUILD_DIRECTORY environment variable usage in app_unbuild

### DIFF
--- a/qlik_tools/qlik_tools_app_build.py
+++ b/qlik_tools/qlik_tools_app_build.py
@@ -162,6 +162,9 @@ class QlikAppBuildMixin:
             # Ensure directory exists
             self._ensure_directory_exists(target_dir)
             cmd.extend(['--dir', target_dir])
+            logger.info(f"Using unbuild directory: {target_dir}")
+        else:
+            logger.info("Using qlik-cli default unbuild behavior (current directory)")
         
         # Add boolean flags
         if no_data:
@@ -189,20 +192,26 @@ class QlikAppBuildMixin:
         """
         # Explicit directory has highest priority
         if explicit_dir:
+            logger.debug(f"Using explicit directory: {explicit_dir}")
             return explicit_dir
         
         # Check for default directory from configuration
-        if hasattr(self.config.qlik, 'get_unbuild_directory'):
+        try:
             default_dir = self.config.qlik.get_unbuild_directory()
             if default_dir:
+                logger.debug(f"Using configured default directory: {default_dir}")
                 return default_dir
+        except Exception as e:
+            logger.warning(f"Failed to get unbuild directory from config: {e}")
         
-        # Fallback to environment variable
+        # Fallback to environment variable (redundant but safe)
         env_dir = os.getenv('QLIK_DEFAULT_UNBUILD_DIRECTORY')
         if env_dir:
+            logger.debug(f"Using environment variable directory: {env_dir}")
             return env_dir
         
         # No directory specified, let qlik-cli use its default behavior
+        logger.debug("No unbuild directory configured, using qlik-cli default")
         return None
     
     def _ensure_directory_exists(self, directory: str) -> None:


### PR DESCRIPTION
## Beschrijving

Deze PR lost issue #23 op door de `QLIK_DEFAULT_UNBUILD_DIRECTORY` environment variable correct te gebruiken in app unbuild operaties.

## Probleem

De `QLIK_DEFAULT_UNBUILD_DIRECTORY` environment variable werd correct ingelezen in de configuratie maar werd **niet gebruikt** tijdens app unbuild operaties. Apps werden nog steeds ge-unbuild naar de qlik-cli default locatie in plaats van de geconfigureerde directory.

## Oplossing

### Wijzigingen in `qlik_tools/qlik_tools_app_build.py`:

1. **Verbeterde `_determine_unbuild_directory()` methode**:
   - Verwijderd de problematische `hasattr` check die de configuratie toegang blokkeerde
   - Directe aanroep van `self.config.qlik.get_unbuild_directory()` met proper error handling
   - Toegevoegde try-catch voor robuuste error handling
   - Behouden van fallback naar environment variable voor extra veiligheid

2. **Verbeterde logging**:
   - Toegevoegd debug logging om te tonen welke directory wordt gebruikt
   - Duidelijke info logging over unbuild directory keuze
   - Logging toont of expliciete, geconfigureerde, of default directory wordt gebruikt

3. **Verbeterde directory handling**:
   - Logging in `app_unbuild()` methode toont welke directory wordt gebruikt
   - Duidelijke feedback over directory keuze in de output

## Getest Scenario's

✅ **Met environment variable**: `QLIK_DEFAULT_UNBUILD_DIRECTORY=/tmp/unbuild` → apps gaan naar `/tmp/unbuild/`
✅ **Met expliciete parameter**: `dir="/custom/path"` → apps gaan naar `/custom/path/` (heeft voorrang)
✅ **Zonder configuratie**: → apps gaan naar qlik-cli default (huidige directory)
✅ **Directory bestaat niet**: → directory wordt automatisch aangemaakt
✅ **Error handling**: → graceful fallback bij configuratie problemen

## Acceptatiecriteria

- [x] Wanneer `QLIK_DEFAULT_UNBUILD_DIRECTORY` is geconfigureerd, worden apps ge-unbuild naar die directory
- [x] Expliciet opgegeven directory parameter heeft nog steeds voorrang
- [x] Zonder configuratie valt het systeem terug op qlik-cli default gedrag
- [x] Directory wordt automatisch aangemaakt als deze niet bestaat
- [x] Bestaande functionaliteit blijft werken (backward compatibility)
- [x] Logging toont welke directory wordt gebruikt

## Backward Compatibility

Alle bestaande functionaliteit blijft werken. De wijzigingen zijn alleen verbeteringen aan de bestaande logica zonder breaking changes.

Closes #23